### PR TITLE
add aws:kms support for SSE

### DIFF
--- a/boto/provider.py
+++ b/boto/provider.py
@@ -56,6 +56,7 @@ SECURITY_TOKEN_HEADER_KEY = 'security-token-header'
 STORAGE_CLASS_HEADER_KEY = 'storage-class'
 MFA_HEADER_KEY = 'mfa-header'
 SERVER_SIDE_ENCRYPTION_KEY = 'server-side-encryption-header'
+SERVER_SIDE_ENCRYPTION_KEY_KEY = 'server-side-encryption-key-header'
 VERSION_ID_HEADER_KEY = 'version-id-header'
 RESTORE_HEADER_KEY = 'restore-header'
 
@@ -122,6 +123,8 @@ class Provider(object):
             SECURITY_TOKEN_HEADER_KEY: AWS_HEADER_PREFIX + 'security-token',
             SERVER_SIDE_ENCRYPTION_KEY: AWS_HEADER_PREFIX +
                                          'server-side-encryption',
+            SERVER_SIDE_ENCRYPTION_KEY_KEY: AWS_HEADER_PREFIX +
+                                         'server-side-encryption-aws-kms-key-id',
             VERSION_ID_HEADER_KEY: AWS_HEADER_PREFIX + 'version-id',
             STORAGE_CLASS_HEADER_KEY: AWS_HEADER_PREFIX + 'storage-class',
             MFA_HEADER_KEY: AWS_HEADER_PREFIX + 'mfa',
@@ -143,6 +146,7 @@ class Provider(object):
             RESUMABLE_UPLOAD_HEADER_KEY: GOOG_HEADER_PREFIX + 'resumable',
             SECURITY_TOKEN_HEADER_KEY: GOOG_HEADER_PREFIX + 'security-token',
             SERVER_SIDE_ENCRYPTION_KEY: None,
+            SERVER_SIDE_ENCRYPTION_KEY_KEY: None,
             # Note that this version header is not to be confused with
             # the Google Cloud Storage 'x-goog-api-version' header.
             VERSION_ID_HEADER_KEY: GOOG_HEADER_PREFIX + 'version-id',
@@ -360,6 +364,7 @@ class Provider(object):
         self.resumable_upload_header = (
             header_info_map[RESUMABLE_UPLOAD_HEADER_KEY])
         self.server_side_encryption_header = header_info_map[SERVER_SIDE_ENCRYPTION_KEY]
+        self.server_side_encryption_key_header = header_info_map[SERVER_SIDE_ENCRYPTION_KEY_KEY]
         self.storage_class_header = header_info_map[STORAGE_CLASS_HEADER_KEY]
         self.version_id = header_info_map[VERSION_ID_HEADER_KEY]
         self.mfa_header = header_info_map[MFA_HEADER_KEY]

--- a/boto/s3/bucket.py
+++ b/boto/s3/bucket.py
@@ -850,7 +850,8 @@ class Bucket(object):
                     src_bucket_name, validate=False)
             acl = src_bucket.get_xml_acl(src_key_name)
         if encrypt_key:
-            headers[provider.server_side_encryption_header] = 'AES256'
+            if provider.server_side_encryption_header not in headers:
+                headers[provider.server_side_encryption_header] = 'AES256'
         src = '%s/%s' % (src_bucket_name, urllib.quote(src_key_name))
         if src_version_id:
             src += '?versionId=%s' % src_version_id


### PR DESCRIPTION
add new enable_kms_encryption() to key.py  - change SSE type in the header to 'aws:kms' and disable md5 checks, as Etag is actually not the checksum when using 'aws:kms'
